### PR TITLE
link with Iconv::Iconv on non-MSW platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ else()
   string(JOIN "\n" EXT2
     "if(NOT TARGET ${libName})"
     "  add_library(${libName} INTERFACE IMPORTED)"
+    "  find_package(Iconv REQUIRED)"
+    "  target_link_libraries(${libName} INTERFACE Iconv::Iconv)"
     "endif()"
     ""
     )


### PR DESCRIPTION
https://github.com/externpro/externpro/issues/187
appears to fix link issue on macOS https://github.com/externpro/buildpro/pull/134#issuecomment-3299670764