### PR TITLE
externpro 25.07.6-44-g0ac4bac

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,0 +1,2 @@
+tag: v1.18.7
+message: "externpro version 1.18.7 tag"

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: v1.18.7
-message: "externpro version 1.18.7 tag"
+tag: xpv1.18.8
+message: "xpro version 1.18.8 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -1,4 +1,7 @@
 name: xpBuild
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
     tags: ["xpv*"]
@@ -7,6 +10,10 @@ on:
   workflow_dispatch:
 jobs:
   linux:
+    permissions:
+      contents: read
+      pull-requests: write
+      packages: write
     uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
     with:
       cmake-workflow-preset: LinuxRelease

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -1,23 +1,23 @@
-name: Build
+name: xpBuild
 on:
   push:
-    branches: [ "dev" ]
+    tags: ["xpv*"]
   pull_request:
-    branches: [ "dev" ]
+    branches: ["xpro"]
   workflow_dispatch:
 jobs:
   linux:
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.3
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
     with:
       cmake-workflow-preset: LinuxRelease
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.3
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
     with:
       cmake-workflow-preset: DarwinRelease
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.3
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
     with:
       cmake-workflow-preset: WindowsRelease
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -1,4 +1,4 @@
-name: Release
+name: xpRelease
 on:
   workflow_dispatch:
     inputs:
@@ -6,10 +6,35 @@ on:
         description: 'URL of the workflow run containing artifacts to upload (e.g., https://github.com/owner/repo/actions/runs/123456789)'
         required: true
         type: string
+  workflow_run:
+    workflows: ["xpBuild"]
+    types: [completed]
 jobs:
+  dispatch-at-tag:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'xpv')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      -
+        name: Dispatch xpRelease at tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TAG_REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${{ github.repository }}/actions/workflows/xprelease.yml/dispatches" \
+            -f ref="$TAG_REF" \
+            -f inputs[workflow_run_url]="$RUN_URL"
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.3
+    if: github.event_name == 'workflow_dispatch'
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -1,0 +1,16 @@
+name: xpTag
+permissions:
+  contents: write
+  issues: write
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  tag:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    with:
+      merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.6-44-g0ac4bac`

## Changes

- Updated `.devcontainer` to externpro `25.07.6-44-g0ac4bac`
- Previous HEAD: `aca2ba80ab3f3009b7cdd6d33fb3bc89c24e27e2`
- New HEAD: `0ac4bac86f2f25110dcf941fb94820bd79c061ec`
- Created `.github/release-tag.yml` (tag: `v1.18.7`)
- If you add the \"release:tag\" label, the tag will be \`v1.18.7\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/libiconv/blob/externpro-update-25.07.6-44-g0ac4bac-21850385850-1/.github/release-tag.yml
- Updated caller workflows to match templates

### Workflow Update Report

⚠️ xpbuild.yml: Template drift detected (outside preserved customizations)
✓ xpbuild.yml: Version updated 25.07.3 → 25.07.6
✓ xpbuild.yml: workflow name updated from template
✓ xpbuild.yml: push.branches updated from template
✓ xpbuild.yml: push.tags updated from template
✓ xpbuild.yml: pull_request.branches updated from template

### Preserved Customizations
🔧 cmake-workflow-preset: LinuxRelease,DarwinRelease,WindowsRelease
🔧 cmake-workflow-preset: LinuxRelease,DarwinRelease,WindowsRelease
🔧 cmake-workflow-preset: LinuxRelease,DarwinRelease,WindowsRelease
✓ xprelease.yml: Synced from template
✓ xptag.yml: Created new workflow from template

---

*This PR was created automatically by GitHub Actions*
